### PR TITLE
Add Redis Instance Support to RedisBackend

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ pip install idemptx
 ## 🚀 Quick Start
 
 ```python
+import redis
 from fastapi import FastAPI, Request
 from idemptx import idempotent
-from idemptx.backend.redis import RedisBackend
+from idemptx.backend import RedisBackend
 
 app = FastAPI()
-redis_backend = RedisBackend()
+client = redis.Redis(host='localhost', port=6379, db=0)
+redis_backend = RedisBackend(client)
 
 @app.post('/orders')
 @idempotent(storage_backend=redis_backend)
@@ -63,6 +65,18 @@ async def create_order(request: Request):
 - `key_ttl`: How long to hold cache and lock (in seconds)
 - `wait_timeout`: Wait for lock to be released (0 = immediate failure)
 - `validate_signature`: Whether to compare request content on replays
+
+---
+
+## 🔀 Async Redis Backend
+
+```python
+import redis.asyncio as aioredis
+from idemptx.backend import AsyncRedisBackend
+
+async_client = aioredis.Redis(host='localhost', port=6379, db=0)
+async_backend = AsyncRedisBackend(async_client)
+```
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "idemptx"
-version = "0.2.0"
+version = "0.2.1"
 description = "Idempotency decorator for FastAPI"
 authors = ["pypy-riley <pypy.riley@gmail.com>"]
 license = "MIT"

--- a/src/idemptx/backend/redis.py
+++ b/src/idemptx/backend/redis.py
@@ -42,12 +42,10 @@ class RedisBackend(StorageBackend, BaseRedisBackend):
 
     def __init__(
         self,
-        host: Annotated[str, 'Redis host'] = 'localhost',
-        port: Annotated[int, 'Redis port'] = 6379,
-        db: Annotated[int, 'Redis DB index'] = 0,
+        redis_instance: redis.Redis,
         prefix: Annotated[str, 'Key prefix namespace'] = 'idempotency:',
     ):
-        self.redis = redis.Redis(host=host, port=port, db=db)
+        self.redis = redis_instance
         super().__init__(prefix=prefix)
 
     def get(self, key: str) -> dict | None:
@@ -72,12 +70,10 @@ class AsyncRedisBackend(AsyncStorageBackend, BaseRedisBackend):
 
     def __init__(
         self,
-        host: Annotated[str, 'Redis host'] = 'localhost',
-        port: Annotated[int, 'Redis port'] = 6379,
-        db: Annotated[int, 'Redis DB index'] = 0,
+        redis_instance: aioredis.Redis,
         prefix: Annotated[str, 'Key prefix namespace'] = 'idempotency:',
     ):
-        self.redis = aioredis.Redis(host=host, port=port, db=db)
+        self.redis = redis_instance
         super().__init__(prefix=prefix)
 
     async def get(self, key: str) -> dict | None:


### PR DESCRIPTION
## 🚀 Summary

This PR refactors the `RedisBackend` and `AsyncRedisBackend` constructors to support a more flexible and robust initialization using pre-configured Redis clients.

## ♻️ What's Changed

- ✅ Replaced `host`, `port`, `db`, and `prefix` arguments with a single `redis_instance` parameter.
- ✅ Users must now pass an existing `redis.Redis` or `redis.asyncio.Redis` client instance.
- ✅ Enables advanced Redis usage, including authentication, TLS, clustering, etc.
- ✅ Updated documentation and examples to reflect the new usage pattern.

## ⚠️ Breaking Change

- ❌ The previous constructor style is no longer supported:
  ```python
  RedisBackend(host='localhost', port=6379)
  ```

- ✅ The new usage:
  ```python
  import redis
  client = redis.Redis(host='localhost', port=6379)
  RedisBackend(client)
  ```

## 📖 Motivation

This design gives developers full control over how Redis is configured, especially when dealing with authentication, Redis URLs, TLS, Sentinel, or cloud-based Redis services.
