### PR TITLE
docs: clarify limitation with response_model in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ async def create_something(request: Request):
 
 ---
 
+## ❗️Limitations
+
+Currently, only `JSONResponse` is supported for caching.
+
+If your endpoint uses `response_model`, the return value is typically a Pydantic model, which FastAPI wraps *after* the decorator has executed. This means the idempotency decorator cannot cache the final serialized response or set headers reliably in this case.
+
+To enable caching, please return a `JSONResponse` explicitly from your endpoint.
+
+Support for `response_model` and automatic response wrapping may be added in a future version.
+
+---
+
 ## 📄 License
 
 MIT License © 2025 [pypy-riley](https://github.com/pypy-riley)


### PR DESCRIPTION
### What’s changed

This PR adds a new **Limitations** section to the README, explaining that only `JSONResponse` (or subclasses of `Response`) are currently supported for caching.

FastAPI applies `response_model` wrapping *after* the decorator is executed, which means the `idempotent` decorator cannot reliably intercept or cache those responses.

### Why

Some users may expect that endpoints using `response_model` are automatically cached, but this is not currently the case. This clarification helps avoid confusion and makes current limitations explicit.

### Future work

Support for `response_model` compatibility and automatic response wrapping may be added in a future version.
