### PR TITLE
Add Makefile and pytest-cov for testing and coverage reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: install test test-cov lint format build publish clean
+
+install:
+	poetry install
+
+test:
+	poetry run pytest tests/
+
+test-cov:
+	poetry run pytest --cov=idemptx tests/
+
+lint:
+	poetry run ruff check src tests
+
+format:
+	poetry run ruff format src tests
+
+build:
+	poetry build
+
+publish: build
+	poetry publish
+
+clean:
+	rm -rf dist .pytest_cache .coverage
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -rf {} +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ pytest = "^8.3.5"
 pytest-asyncio = "^0.26.0"
 httpx = "^0.28.1"
 fakeredis = "^2.28.1"
+pytest-cov = "^6.1.1"
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
# 🛠️ Add Makefile for Common Dev Tasks

This PR introduces a `Makefile` to standardize and simplify local development workflows for the `idemptx` project.

## ✨ What's Added

A new `Makefile` with the following targets:

- `make install` – Install all project dependencies via Poetry
- `make test` – Run the test suite
- `make test-cov` – Run tests with coverage using `pytest-cov`
- `make lint` – Check code style using `ruff`
- `make format` – Format code using `ruff`
- `make build` – Build the package (via `poetry build`)
- `make publish` – Publish the package to PyPI (requires auth)
- `make clean` – Remove build artifacts, cache, and Python bytecode

## 🧪 Dev Dependency Added

- [`pytest-cov`](https://pypi.org/project/pytest-cov/) – for test coverage tracking

## 🤔 Why

- Unifies and documents common project tasks
- Makes it easier for contributors and maintainers to run tests, format code, and publish releases
- Reduces the need to remember long `poetry` or `pytest` commands

---

This change is **development-only** and does not affect runtime logic.
